### PR TITLE
Add date_time to accesses api

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Uma aplicação web que possibilita ao usuário obter informações sobre os cas
 
 ## Documentação da API de acessos
 
-- O caminho para consultar a API de acessos localmente é http://localhost
+O caminho para consultar a API de acessos localmente é http://localhost
 
 ### Obter último acesso
 
@@ -111,9 +111,9 @@ Uma aplicação web que possibilita ao usuário obter informações sobre os cas
 
 ```json
 {
-  "id":10,
-  "country":"Canada",
-  "created_at":"2023-03-17T05:03:37.000000Z"
+  "id":17,
+  "country":"Australia",
+  "date_time":"2023-03-20 16:21:15"
 }
 ```
 
@@ -121,11 +121,12 @@ Uma aplicação web que possibilita ao usuário obter informações sobre os cas
 
 **Endpoint: POST /api/accesses**
 
-#### Parâmetro que deve ser enviado para a criação de um acesso:
+#### Os dados para a criação de um acesso devem ser enviados no seguinte formato:
 
 ```json
 {
-  "country":"Brazil"
+  "country":"Brazil",
+  "date_time":"2023-03-20 17:15:20"
 }
 ```
 
@@ -136,17 +137,18 @@ Uma aplicação web que possibilita ao usuário obter informações sobre os cas
   "message":"Acesso registrado com sucesso!",
   "data":{
     "country":"Brazil",
-    "created_at":"2023-03-17T05:40:25.000000Z",
-    "id":14
+    "date_time":"2023-03-20 17:15:20",
+    "id":18
   }
 }
 ```
 
-#### Cenário de erro com parâmetro obrigatório não enviado:
+#### Cenário de erro com parâmetros inválidos:
 
 ```json
 {
-  "country":""
+  "country":"",
+  "date_time":"20-03-2023 17:20:34"
 }
 ```
 
@@ -154,10 +156,13 @@ Uma aplicação web que possibilita ao usuário obter informações sobre os cas
 
 ```json
 {
-  "message": "The country field is required.",
+  "message": "O campo país não pode ficar em branco. (and 1 more error)",
   "errors": {
     "country": [
-      "The country field is required."
+      "O campo país não pode ficar em branco."
+    ],
+    "date_time": [
+      "O campo data deve estar no formato Y-m-d H:i:s."
     ]
   }
 }

--- a/back-end/app/Http/Requests/API/AccessesStoreRequest.php
+++ b/back-end/app/Http/Requests/API/AccessesStoreRequest.php
@@ -22,7 +22,17 @@ class AccessesStoreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'country' => 'required'
+            'country' => 'required',
+            'date_time' => 'required|date_format:Y-m-d H:i:s'
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'country.required' => 'O campo país não pode ficar em branco.',
+            'date_time.required' => 'O campo data não pode ficar em branco.',
+            'date_time.date_format' => 'O campo data deve estar no formato Y-m-d H:i:s.'
         ];
     }
 }

--- a/back-end/app/Models/Access.php
+++ b/back-end/app/Models/Access.php
@@ -8,6 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 class Access extends Model
 {
     use HasFactory;
-    protected $fillable = ['country'];
-    protected $hidden = ['updated_at'];
+    protected $fillable = ['country', 'date_time'];
+    protected $hidden = ['created_at', 'updated_at'];
 }

--- a/back-end/database/factories/AccessFactory.php
+++ b/back-end/database/factories/AccessFactory.php
@@ -17,7 +17,8 @@ class AccessFactory extends Factory
     public function definition(): array
     {
         return [
-            'country' => $this->faker->country
+            'country' => $this->faker->country,
+            'date_time' => now()->format('Y-m-d H:i:s')
         ];
     }
 }

--- a/back-end/database/migrations/2023_03_20_154015_add_date_time_to_accesses_table.php
+++ b/back-end/database/migrations/2023_03_20_154015_add_date_time_to_accesses_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('accesses', function (Blueprint $table) {
+            $table->dateTime('date_time');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('accesses', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/back-end/tests/Feature/API/AccessesControllerTest.php
+++ b/back-end/tests/Feature/API/AccessesControllerTest.php
@@ -20,7 +20,7 @@ class AccessesControllerTest extends TestCase
         $response->assertStatus(200);
 
         $response->assertJson(function(AssertableJson $json) use($last_access){
-            $json->hasAll(['id', 'country', 'created_at']);
+            $json->hasAll(['id', 'country', 'date_time']);
             $json->whereAllType(['id' => 'integer', 'country' => 'string']);
             $json->whereAll(['country' => $last_access->country]);
         });
@@ -30,24 +30,38 @@ class AccessesControllerTest extends TestCase
     {
         $access = Access::factory(1)->makeOne()->toArray();
         $response = $this->postJson('/api/accesses', $access);
+
         $response->assertStatus(201);
 
         $response->assertJson(function(AssertableJson $json) use($access){
-            $json->hasAll(['message', 'data.country', 'data.created_at', 'data.id']);
+            $json->hasAll(['message', 'data.country', 'data.date_time', 'data.id']);
             $json->whereAll([
                 'message' => 'Acesso registrado com sucesso!',
                 'data.country' => $access['country']])->etc();
         });
     }
 
-    public function test_post_validate_create_accesses(): void
+    public function test_post_validate_required_fields_on_create_accesses(): void
     {
         $response = $this->postJson('/api/accesses', []);
         $response->assertUnprocessable();
 
         $response->assertJson(function(AssertableJson $json){
             $json->hasAll(['message', 'errors']);
-            $json->where('errors.country.0', 'The country field is required.');
+            $json->where('errors.country.0', 'O campo país não pode ficar em branco.')
+                 ->where('errors.date_time.0', 'O campo data não pode ficar em branco.');
+        });
+    }
+
+    public function test_post_validate_date_time_format_on_create_accesses(): void
+    {
+        $response = $this->postJson('/api/accesses', ["country" => "Canada",
+                                                      "date_time" => "20-03-2023 17:20:34"]);
+        $response->assertUnprocessable();
+
+        $response->assertJson(function(AssertableJson $json){
+            $json->hasAll(['message', 'errors']);
+            $json->where('errors.date_time.0', 'O campo data deve estar no formato Y-m-d H:i:s.');
         });
     }
 }

--- a/front-end/scripts/api_accesses.js
+++ b/front-end/scripts/api_accesses.js
@@ -1,13 +1,14 @@
 const ACCESSES = {
   postCountry: async(country_name) => {
-    let country = { country: country_name }
+    let currentTime = formatDateForPost()
+    let data = { country: country_name, date_time: currentTime }
     return await fetch("http://localhost/api/accesses", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "X-Requested-With": "XMLHttpRequest"
       },
-      body: JSON.stringify(country),
+      body: JSON.stringify(data),
     })
     .then((response) => response.json())
     .then((data) => {
@@ -27,5 +28,12 @@ const ACCESSES = {
     .catch((error) => {
       console.log(`Ops, ocorreu um erro ${error}`)
     })
-  }
+  },
+}
+
+formatDateForPost = () => {
+  let currentTime = new Date().toLocaleString().replace(',','')
+  let date = currentTime.split(' ')[0].split("/").reverse().join('-')
+  let time = currentTime.split(' ')[1]
+  return `${date} ${time}`
 }

--- a/front-end/scripts/countries.js
+++ b/front-end/scripts/countries.js
@@ -21,7 +21,7 @@ async function displayDataByCountry(){
     let data = await prepareCountryDataForDisplay(url, country)
     await prepareStatesDataForDisplay(data)
     let lastAccessData = await ACCESSES.postCountry(country)
-    displayFooterData(lastAccessData)
+    updateFooterData(lastAccessData)
   }
   COUNTRIES_DATA.lockMode = false
 }

--- a/front-end/scripts/footer.js
+++ b/front-end/scripts/footer.js
@@ -9,7 +9,7 @@ async function displayDataInFooter(){
   let data = await ACCESSES.getLastAccess()
 
   loading.style.display = 'none'
-  lastDate.innerHTML = `Data: ${formatValue(new Date(data.created_at))}`
+  lastDate.innerHTML = `Data: ${formatDateToDisplay(data.date_time)}`
   lastCountry.innerHTML = `País: ${data.country}`
   
   footer.appendChild(lastDate)
@@ -26,10 +26,16 @@ function hideFooterData(){
   loading.style.display = 'inline-block'
 }
 
-function displayFooterData(data){
+function updateFooterData(data){
   loading.style.display = 'none'
-  lastDate.innerHTML = `Data: ${formatValue(new Date(data.created_at))}`
+  lastDate.innerHTML = `Data: ${formatDateToDisplay(data.date_time)}`
   lastCountry.innerHTML = `País: ${data.country}`
   lastDate.style.display = 'inline-block'
   lastCountry.style.display = 'inline-block'
+}
+
+function formatDateToDisplay(dateTime){
+  let date = dateTime.split(' ')[0].split("-").reverse().join('/')
+  let time = dateTime.split(' ')[1]
+  return `${date}, ${time}`
 }


### PR DESCRIPTION
- [x] Substituir created_at por date_time na api de acessos para armazenar a data e hora enviadas pelo script ao fazer um POST no endpoint /api/accesses.